### PR TITLE
disconnect the channel when a streamer goes offline. 

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -46,7 +46,11 @@ const Bot = {
           }
           break;
         case "ended":
-          Bot.channels = Bot.channels.filter((c)=> c.id !== channelId);
+          if (channel) {
+            channel.disconnect();
+          }
+
+          Bot.channels = Bot.channels.filter((c)=> !c.disconnected);
           break;
         case "new_message":
           const author = message.author;

--- a/src/channel.js
+++ b/src/channel.js
@@ -16,6 +16,20 @@ export default class Channel {
     this.startTimer();
   }
 
+  get disconnected() {
+    return this.id === null;
+  }
+
+  // Ensure everything is reset
+  disconnect() {
+    this.clearTimer();
+    this.id = null;
+    this.usernames = [];
+    this.timer = null;
+    this.cb = (_n, _a)=> {};
+    this.silent = true;
+  }
+
   addUser(user) {
     this.usernames.push(user);
   }


### PR DESCRIPTION
Fixes #4

This adds a disconnect function to the channel so when a streamer goes offline, all of the data is reset. This also makes it easier to check for bad channels in the bot.