### PR TITLE
Allow for shorter chat times in development, but longer in production

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,14 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+
 // return a random time length. This is number of minutes
 export function waiverTime() {
-  const times = [2.5, 3.0, 3.25, 3.5, 3.75, 4, 4.5, 5, 7, 10];
+  let times;
+  if (process.env.NODE_ENV === "development") {
+    times = [1, 2, 3];
+  } else {
+    times = [5, 5.5, 6, 7, 8, 10, 12.5, 15];
+  }
+
   return times[Math.floor(Math.random() * times.length)];
 }


### PR DESCRIPTION
This increases the chat times while in production. For channels that sit empty for hours, this should help reduce the amount of noise, but still allow the feedback loop to be short in development.