### PR TITLE
If there's no users in the channel, then keep the bot quiet.

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -25,7 +25,6 @@ const Bot = {
   channels: [],
   handleMessage: (ws, receivedMessage)=> {
     if (receivedMessage.type === "ping") { return; }
-    console.log("RECEIVED MESSAGE", receivedMessage)
 
     if (receivedMessage.message) {
       const message = receivedMessage.message;
@@ -72,7 +71,6 @@ const Bot = {
           break;
         case "enter_stream":
           if (channel) {
-            console.log(message.text, "has entered the stream")
             user = {name: message.text, id: channelId};
             if (!channel.hasUser(user)) {
               channel.addUser(user);
@@ -82,7 +80,6 @@ const Bot = {
           break;
         case "leave_stream":
           if (channel) {
-            console.log(message.text, "has left the stream")
             user = {name: message.text, id: channelId};
             if (channel.hasUser(user)) {
               channel.removeUser(user);

--- a/src/channel.js
+++ b/src/channel.js
@@ -1,5 +1,5 @@
 import getRandomMessage from "./messages.js";
-import { waiverTime } from "./utils.js";
+import { waiverTime, log } from "./utils.js";
 
 export default class Channel {
   id;
@@ -13,7 +13,6 @@ export default class Channel {
     this.timer = null;
     this.cb = cb;
     this.silent = false;
-    this.startTimer();
   }
 
   get disconnected() {
@@ -22,6 +21,7 @@ export default class Channel {
 
   // Ensure everything is reset
   disconnect() {
+    log("Disconnecting Channel");
     this.clearTimer();
     this.id = null;
     this.usernames = [];
@@ -30,29 +30,47 @@ export default class Channel {
     this.silent = true;
   }
 
+  // If there's no timer, and the channel isn't silent
+  // then start up a new timer now that a user is here
   addUser(user) {
+    log(`Adding user ${user.name}`);
     this.usernames.push(user);
+    log(`TOTAL USERS ${this.usernames.length}`)
+    if (!this.timer && !this.silent) {
+      this.startTimer();
+    }
   }
 
+  // When there's no one left in the channel, turn off the timer
   removeUser(user) {
+    log(`Removing user ${user.name}`);
     this.usernames = this.usernames.filter((u)=> u.name !== user.name);
+
+    if (this.usernames.length === 0) {
+      this.clearTimer();
+    }
   }
 
+  // Returns `true` if the user is already in the channel
   hasUser(user) {
     return this.usernames.map((u) => u.name).includes(user.name);
   }
 
   silence() {
+    log(`Silence channel`);
     this.clearTimer();
     this.silent = true;
   }
 
   resume() {
+    log(`Resume channel`);
     this.silent = false;
     this.resetTimer();
   }
 
+  // Clear the current timer and start a new one unless the channel is silent
   resetTimer() {
+    log(`Resetting timer`);
     if (!this.silent) {
       this.clearTimer();
       this.startTimer();
@@ -61,7 +79,7 @@ export default class Channel {
 
   startTimer() {
     const runtime = 1000 * 60 * waiverTime();
-    console.log("Starting timer", runtime)
+    log(`Starting timer ${runtime}`);
     this.timer = setInterval(()=> {
       const user = this.usernames[Math.floor(Math.random() * this.usernames.length)];
       let randomMessage;
@@ -75,8 +93,9 @@ export default class Channel {
     }, runtime);
   }
 
+  // clears the timer
   clearTimer() {
-    console.log("Clearing timer")
+    log(`Clearing timer`);
     clearInterval(this.timer);
     this.timer = null;
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,3 +12,9 @@ export function waiverTime() {
 
   return times[Math.floor(Math.random() * times.length)];
 }
+
+export function log(message) {
+  if (process.env.NODE_ENV === "development") {
+    console.log(message);
+  }
+}


### PR DESCRIPTION
Fixes #8

The point of the bot is to get people talking, but if there's no one in the room to talk, then the bot is just wasting the messages. So now instead of kicking on the timer right when the channel is instantiated, we wait for someone to join the channel, and when they leave, we check if anyone else is still in the room.