### PR TITLE
Removing the short times

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -3,13 +3,7 @@ dotenv.config();
 
 // return a random time length. This is number of minutes
 export function waiverTime() {
-  let times;
-  if (process.env.NODE_ENV === "development") {
-    times = [1, 2, 3];
-  } else {
-    times = [5, 5.5, 6, 7, 8, 10, 12.5, 15];
-  }
-
+  const  times = [5, 5.5, 6, 7, 8, 10, 12.5, 15];
   return times[Math.floor(Math.random() * times.length)];
 }
 


### PR DESCRIPTION
Even though I have `NODE_ENV` set to production, chatterbot still keeps posting in 1 and 2 minute intervals. I have no clue why, so I'm removing all possible chance of posting less than 5 min intervals.